### PR TITLE
fix: Correct shader logic and memory management

### DIFF
--- a/Runtime/Builtin/CensorEffectBuiltin.cs
+++ b/Runtime/Builtin/CensorEffectBuiltin.cs
@@ -31,13 +31,22 @@ namespace CensorEffect.Runtime.Builtin
         {
             if (_censorCamera != null)
             {
+                #if UNITY_EDITOR
                 DestroyImmediate(_censorCamera.gameObject);
+                #else
+                Destroy(_censorCamera.gameObject);
+                #endif
                 _censorCamera = null;
             }
-            if (_censorMaskTexture != null)
+
+            if (_blurMaterial != null)
             {
-                RenderTexture.ReleaseTemporary(_censorMaskTexture);
-                _censorMaskTexture = null;
+                #if UNITY_EDITOR
+                DestroyImmediate(_blurMaterial);
+                #else
+                Destroy(_blurMaterial);
+                #endif
+                _blurMaterial = null;
             }
         }
 
@@ -67,13 +76,13 @@ namespace CensorEffect.Runtime.Builtin
             _censorEffect.UpdateMaterialProperties(_mainCamera);
 
             // Get a temporary texture for the mask
-            _censorMaskTexture = RenderTexture.GetTemporary(source.width, source.height, 0, RenderTextureFormat.A8);
+            var censorMaskTexture = RenderTexture.GetTemporary(source.width, source.height, 0, RenderTextureFormat.A8);
 
             // Setup and render the mask
             var censorCam = GetCensorCamera();
             censorCam.CopyFrom(_mainCamera);
             censorCam.cullingMask = _censorEffect.CensorLayer;
-            censorCam.targetTexture = _censorMaskTexture;
+            censorCam.targetTexture = censorMaskTexture;
             censorCam.clearFlags = CameraClearFlags.SolidColor;
             censorCam.backgroundColor = Color.clear;
             censorCam.RenderWithShader(_censorEffect.CensorMaskMaterial.shader, "RenderType");
@@ -84,20 +93,20 @@ namespace CensorEffect.Runtime.Builtin
                 _blurMaterial.SetFloat("_BlurSize", _censorEffect.CensorAreaExpansion);
                 var tempBlurTex = RenderTexture.GetTemporary(source.width, source.height, 0, RenderTextureFormat.A8);
 
-                Graphics.Blit(_censorMaskTexture, tempBlurTex, _blurMaterial, 0); // Horizontal
-                Graphics.Blit(tempBlurTex, _censorMaskTexture, _blurMaterial, 1); // Vertical
+                Graphics.Blit(censorMaskTexture, tempBlurTex, _blurMaterial, 0); // Horizontal
+                Graphics.Blit(tempBlurTex, censorMaskTexture, _blurMaterial, 1); // Vertical
 
                 RenderTexture.ReleaseTemporary(tempBlurTex);
             }
 
             // Set the mask texture for the effect material
-            _censorEffect.CensorEffectMaterial.SetTexture(CensorEffect.CensorMaskID, _censorMaskTexture);
+            _censorEffect.CensorEffectMaterial.SetTexture(CensorEffect.CensorMaskID, censorMaskTexture);
 
             // Blit the final effect
             Graphics.Blit(source, destination, _censorEffect.CensorEffectMaterial);
 
             // Cleanup
-            RenderTexture.ReleaseTemporary(_censorMaskTexture);
+            RenderTexture.ReleaseTemporary(censorMaskTexture);
         }
     }
 }

--- a/Runtime/Common/CensorEffect.cs
+++ b/Runtime/Common/CensorEffect.cs
@@ -79,13 +79,21 @@ namespace CensorEffect.Runtime
         {
             if (CensorMaskMaterial != null)
             {
+                #if UNITY_EDITOR
                 DestroyImmediate(CensorMaskMaterial);
+                #else
+                Destroy(CensorMaskMaterial);
+                #endif
                 CensorMaskMaterial = null;
             }
 
             if (CensorEffectMaterial != null)
             {
+                #if UNITY_EDITOR
                 DestroyImmediate(CensorEffectMaterial);
+                #else
+                Destroy(CensorEffectMaterial);
+                #endif
                 CensorEffectMaterial = null;
             }
         }

--- a/Runtime/Common/Resources/Blur.shader
+++ b/Runtime/Common/Resources/Blur.shader
@@ -45,15 +45,15 @@ Shader "Hidden/CensorBlur"
             fixed4 frag (v2f i) : SV_Target
             {
                 float4 col = 0;
-                float2 uv = i.uv;
-                float halfBlur = _BlurSize * 0.5;
+                int radius = (int)_BlurSize;
+                int sampleCount = 0;
 
-                // Simple box blur for performance
-                for (float x = -halfBlur; x <= halfBlur; x++)
+                for (int x = -radius; x <= radius; x++)
                 {
-                    col += tex2D(_MainTex, uv + float2(x * _MainTex_TexelSize.x, 0));
+                    col += tex2D(_MainTex, i.uv + float2(x * _MainTex_TexelSize.x, 0));
+                    sampleCount++;
                 }
-                return col / (_BlurSize);
+                return col / sampleCount;
             }
             ENDCG
         }
@@ -93,14 +93,15 @@ Shader "Hidden/CensorBlur"
             fixed4 frag (v2f i) : SV_Target
             {
                 float4 col = 0;
-                float2 uv = i.uv;
-                float halfBlur = _BlurSize * 0.5;
+                int radius = (int)_BlurSize;
+                int sampleCount = 0;
 
-                for (float y = -halfBlur; y <= halfBlur; y++)
+                for (int y = -radius; y <= radius; y++)
                 {
-                    col += tex2D(_MainTex, uv + float2(0, y * _MainTex_TexelSize.y));
+                    col += tex2D(_MainTex, i.uv + float2(0, y * _MainTex_TexelSize.y));
+                    sampleCount++;
                 }
-                return col / (_BlurSize);
+                return col / sampleCount;
             }
             ENDCG
         }

--- a/Runtime/Common/Resources/CensorEffect.shader
+++ b/Runtime/Common/Resources/CensorEffect.shader
@@ -2,91 +2,76 @@ Shader "Hidden/CensorEffect"
 {
     Properties
     {
-        [HideInInspector] _MainTex("Screen", 2D) = "white" {}
-        [HideInInspector] _CensorMask("Censor Mask", 2D) = "black" {}
-        [HideInInspector] _PixelSize("Pixel Size", Float) = 10.0
-        [HideInInspector] _CensorAreaExpansion("Censor Area Expansion", Float) = 0.0
-        [HideInInspector] _AntiAliasing("Anti-Aliasing", Float) = 1
+        [HideInInspector] _MainTex ("Screen", 2D) = "white" {}
+        [HideInInspector] _CensorMask ("Censor Mask", 2D) = "black" {}
+        [HideInInspector] _PixelSize ("Pixel Size", Float) = 10.0
+        [HideInInspector] _AntiAliasing ("Anti-Aliasing", Float) = 1.0
     }
-
     SubShader
     {
-        Tags { "RenderType" = "Opaque" "RenderPipeline" = "UniversalPipeline" }
-        LOD 100
-        ZWrite Off
-        Cull Off
-        ZTest Always
+        Cull Off ZWrite Off ZTest Always
 
         Pass
         {
-            Name "CensorEffect"
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "UnityCG.cginc"
 
-            HLSLPROGRAM
-            #pragma vertex Vert
-            #pragma fragment Frag
-
-            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
-            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
-
-            struct Attributes
+            struct appdata
             {
-                float4 positionOS   : POSITION;
-                float2 uv           : TEXCOORD0;
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
             };
 
-            struct Varyings
+            struct v2f
             {
-                float4 positionHCS  : SV_POSITION;
-                float2 uv           : TEXCOORD0;
+                float2 uv : TEXCOORD0;
+                float4 vertex : SV_POSITION;
             };
 
-            TEXTURE2D(_MainTex);
-            SAMPLER(sampler_MainTex);
-            TEXTURE2D(_CensorMask);
-            SAMPLER(sampler_CensorMask);
-
-            CBUFFER_START(UnityPerMaterial)
-            float4 _MainTex_ST;
+            sampler2D _MainTex;
+            sampler2D _CensorMask;
             float _PixelSize;
-            float _CensorAreaExpansion;
             float _AntiAliasing;
-            CBUFFER_END
 
-            Varyings Vert(Attributes input)
+            v2f vert (appdata v)
             {
-                Varyings output;
-                output.positionHCS = TransformObjectToHClip(input.positionOS.xyz);
-                output.uv = input.uv;
-                return output;
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = v.uv;
+                return o;
             }
 
-            half4 Frag(Varyings input) : SV_Target
+            fixed4 frag (v2f i) : SV_Target
             {
                 // Calculate pixelated coordinates
                 float2 pixelGrid = _ScreenParams.xy / _PixelSize;
-                float2 pixelatedUV = round(input.uv * pixelGrid) / pixelGrid;
+                float2 pixelatedUV = round(i.uv * pixelGrid) / pixelGrid;
 
                 // Sample original color
-                half4 originalColor = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, input.uv);
+                fixed4 originalColor = tex2D(_MainTex, i.uv);
 
-                // Sample mask
-                half mask = SAMPLE_TEXTURE2D(_CensorMask, sampler_CensorMask, pixelatedUV).a;
+                // Sample mask from the pixelated UV to ensure mask aligns with pixels
+                fixed mask = tex2D(_CensorMask, pixelatedUV).a;
 
                 if (mask > 0.01)
                 {
-                    half4 pixelatedColor = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, pixelatedUV);
+                    fixed4 pixelatedColor = tex2D(_MainTex, pixelatedUV);
 
+                    // Apply anti-aliasing if enabled
                     if (_AntiAliasing > 0.5)
                     {
-                        half smoothMask = smoothstep(0.2, 0.8, mask);
-                        return lerp(originalColor, pixelatedColor, smoothMask);
+                        // Use the original (non-pixelated) mask sample for a smoother edge
+                        fixed smoothMask = tex2D(_CensorMask, i.uv).a;
+                        return lerp(originalColor, pixelatedColor, smoothstep(0.0, 1.0, smoothMask));
                     }
-                    return lerp(originalColor, pixelatedColor, mask);
+                    return pixelatedColor;
                 }
 
                 return originalColor;
             }
-            ENDHLSL
+            ENDCG
         }
     }
     Fallback Off

--- a/Runtime/URP/CensorFeature.cs
+++ b/Runtime/URP/CensorFeature.cs
@@ -8,6 +8,12 @@ namespace CensorEffect.Runtime.URP
         private CensorRenderPass _censorPass;
         private CensorEffect _censorEffect;
 
+        protected override void Dispose(bool disposing)
+        {
+            _censorPass?.Dispose();
+            _censorPass = null;
+        }
+
         public override void Create()
         {
             // This is called by the URP renderer

--- a/Runtime/URP/CensorRenderPass.cs
+++ b/Runtime/URP/CensorRenderPass.cs
@@ -30,6 +30,21 @@ namespace CensorEffect.Runtime.URP
                     _blurMaterial = new Material(shader);
                 }
             }
+
+            // Drawing settings only need to be created once
+            _drawingSettings = new DrawingSettings(new ShaderTagId("UniversalForward"), new SortingSettings());
+        }
+
+        public void Dispose()
+        {
+            if (_blurMaterial != null)
+            {
+                #if UNITY_EDITOR
+                Object.DestroyImmediate(_blurMaterial);
+                #else
+                Object.Destroy(_blurMaterial);
+                #endif
+            }
         }
 
         public void Setup(RenderTargetIdentifier cameraColorTarget)
@@ -55,9 +70,11 @@ namespace CensorEffect.Runtime.URP
 
             // 1. Draw the censor mask
             _censorEffect.UpdateMaterialProperties(renderingData.cameraData.camera);
-            _drawingSettings = CreateDrawingSettings(new ShaderTagId("UniversalForward"), ref renderingData, SortingCriteria.CommonOpaque);
+
+            _drawingSettings.sortingSettings = new SortingSettings(renderingData.cameraData.camera) { criteria = SortingCriteria.CommonOpaque };
             _drawingSettings.overrideMaterial = _censorEffect.CensorMaskMaterial;
             _drawingSettings.overrideMaterialPassIndex = 0;
+
             context.DrawRenderers(renderingData.cullResults, ref _drawingSettings, ref _filteringSettings);
 
             // 2. Blur the mask


### PR DESCRIPTION
This commit addresses several issues found during a code review:

- Corrects the box blur algorithm in Blur.shader to use an integer-based loop and proper normalization.
- Rewrites CensorEffect.shader in CG to ensure compatibility with both the Built-in and Universal Render Pipelines.
- Fixes multiple memory leaks where Materials created at runtime were not being destroyed. This is resolved in both the URP and Built-in render paths.
- Ensures DestroyImmediate is only called within the editor via preprocessor directives.
- Optimizes the URP render pass by caching DrawingSettings to reduce per-frame allocations.