### PR TITLE
Fix Censor Area Expansion and Dynamic Object Occlusion

### DIFF
--- a/Runtime/CensorEffect.cs
+++ b/Runtime/CensorEffect.cs
@@ -143,25 +143,16 @@ namespace CensorEffect.Runtime
 
         private void ApplyBlur(RenderTexture texture)
         {
-            // Downsample for performance
-            var blurDescriptor = new RenderTextureDescriptor(texture.width / 4, texture.height / 4, RenderTextureFormat.R8, 0);
-            var tempBlurTex = RenderTexture.GetTemporary(blurDescriptor);
+            // Get a temporary texture for the blur passes that matches the source
+            var tempBlurTex = RenderTexture.GetTemporary(texture.descriptor);
 
             BlurMaterial.SetFloat(BlurSizeID, CensorAreaExpansion);
 
-            // Blit from full-res mask to downsampled temp texture
-            Graphics.Blit(texture, tempBlurTex);
-
             // Perform blur passes
-            var tempBlurTex2 = RenderTexture.GetTemporary(blurDescriptor);
-            Graphics.Blit(tempBlurTex, tempBlurTex2, BlurMaterial, 0); // Horizontal
-            Graphics.Blit(tempBlurTex2, tempBlurTex, BlurMaterial, 1); // Vertical
-
-            // Blit from downsampled blurred texture back to the full-res mask
-            Graphics.Blit(tempBlurTex, texture);
+            Graphics.Blit(texture, tempBlurTex, BlurMaterial, 0); // Horizontal
+            Graphics.Blit(tempBlurTex, texture, BlurMaterial, 1); // Vertical
 
             RenderTexture.ReleaseTemporary(tempBlurTex);
-            RenderTexture.ReleaseTemporary(tempBlurTex2);
         }
 
         private void UpdateMaterialProperties()
@@ -229,18 +220,15 @@ namespace CensorEffect.Runtime
         {
             if (source == null || target == null) return;
 
-            target.transform.position = source.transform.position;
-            target.transform.rotation = source.transform.rotation;
-            target.fieldOfView = source.fieldOfView;
-            target.nearClipPlane = source.nearClipPlane;
-            target.farClipPlane = source.farClipPlane;
-            target.orthographic = source.orthographic;
-            target.orthographicSize = source.orthographicSize;
-            target.aspect = source.aspect;
+            // Copy all settings from the source camera. This is more robust than
+            // manually copying properties, as it includes settings like cullingMatrix.
+            target.CopyFrom(source);
 
+            // Override specific settings for the censor mask rendering
             target.cullingMask = CensorLayer;
             target.clearFlags = CameraClearFlags.SolidColor;
             target.backgroundColor = Color.clear;
+            target.useOcclusionCulling = false; // Occlusion is handled by the shader
         }
 
         private Material CreateMaterial(Shader shader)


### PR DESCRIPTION
This commit addresses two issues with the CensorEffect script.

1.  CensorAreaExpansion Shrinking Effect: The blur applied to the censor mask was performed on a heavily downsampled texture. This caused a loss of intensity for smaller censored objects, which, after being processed by a smoothstep function, resulted in the censored area shrinking as the blur radius increased. The fix removes the downsampling, performing the blur on the full-resolution mask to ensure the expansion behaves as expected.

2.  Occlusion for Dynamic Objects: The camera responsible for rendering the censor mask was not being fully synchronized with the main camera. Specifically, it was missing properties like the culling matrix, which can be crucial for correctly determining the visibility of dynamic objects. The fix replaces the manual property-by-property copying with a call to `Camera.CopyFrom()`, ensuring a complete and robust synchronization between the cameras. This allows for correct occlusion of and by dynamic objects.