### PR TITLE
Fix: Remove problematic OnDisable logic to prevent conflicts

### DIFF
--- a/Runtime/CensorEffect.cs
+++ b/Runtime/CensorEffect.cs
@@ -75,11 +75,6 @@ namespace CensorEffect.Runtime
 
         private void OnDisable()
         {
-            // It's good practice to clean up the depth texture mode flag if this component added it.
-            if (_mainCamera != null)
-            {
-                _mainCamera.depthTextureMode &= ~DepthTextureMode.Depth;
-            }
             CleanupResources();
         }
 


### PR DESCRIPTION
The CensorEffect script would unconditionally disable the camera's depth texture mode in OnDisable. This caused conflicts with other systems that also rely on the depth texture (like motion vectors), leading to warnings in the console.

A previous attempt to fix this by checking `motionVectorGenerationMode` introduced a compilation error on older Unity versions.

This change corrects the fix by removing the problematic logic from `OnDisable` entirely. This is a safer, more compatible approach that resolves the original warning without introducing compilation errors.