### PR TITLE
Fix(Render): Correct occlusion and non-AA pixelated borders

### DIFF
--- a/Runtime/CensorEffect.cs
+++ b/Runtime/CensorEffect.cs
@@ -79,7 +79,7 @@ namespace CensorEffect.Runtime
 
             UpdateMaterialProperties();
 
-            var maskDescriptor = new RenderTextureDescriptor(source.width, source.height, RenderTextureFormat.R8, 0)
+            var maskDescriptor = new RenderTextureDescriptor(source.width, source.height, RenderTextureFormat.R8, 16)
             {
                 msaaSamples = EnableAntiAliasing ? GetMsaaSampleCount(source) : 1
             };
@@ -197,21 +197,19 @@ namespace CensorEffect.Runtime
         {
             if (source == null || target == null) return;
 
-            // Manually copy essential properties instead of using Camera.CopyFrom()
-            target.transform.position = source.transform.position;
-            target.transform.rotation = source.transform.rotation;
-            target.fieldOfView = source.fieldOfView;
-            target.nearClipPlane = source.nearClipPlane;
-            target.farClipPlane = source.farClipPlane;
-            target.orthographic = source.orthographic;
-            target.orthographicSize = source.orthographicSize;
-            target.aspect = source.aspect;
+            // Copy all properties from the source camera, which is more robust than
+            // manually setting each property. This ensures properties like the
+            // projection matrix are correctly synchronized, which is crucial for
+            // depth buffer sampling.
+            target.CopyFrom(source);
 
+            // Override specific properties for the censor camera's unique role.
             target.depthTextureMode |= DepthTextureMode.Depth;
             target.cullingMask = CensorLayer;
             target.clearFlags = CameraClearFlags.SolidColor;
             target.backgroundColor = Color.clear;
             target.useOcclusionCulling = false;
+            target.allowMSAA = true; // Ensure MSAA is explicitly allowed
         }
 
         private int GetMsaaSampleCount(RenderTexture source)

--- a/Runtime/Resources/CensorEffect.shader
+++ b/Runtime/Resources/CensorEffect.shader
@@ -66,25 +66,25 @@ Shader "Hidden/CensorEffect"
                 // 3. Sample the original texture at the snapped UV to get a blocky, pixelated color.
                 fixed4 pixelatedColor = tex2D(_MainTex, pixelatedUV);
 
-                // Sample the pre-processed (MSAA-resolved and dilated) censor mask.
-                // We only need the red channel since it's an R8 texture.
-                fixed mask = tex2D(_CensorMask, i.uv).r;
-
-                // Process the mask edge based on the anti-aliasing setting.
+                // Sample the censor mask. The method depends on the anti-aliasing setting.
+                fixed mask;
                 if (_AntiAliasing > 0.5)
                 {
-                    // Soft edges: Use smoothstep to create a soft, anti-aliased transition
+                    // For soft edges, sample the mask at the fragment's native UV.
+                    // Then, use smoothstep to create a soft, anti-aliased transition
                     // between the non-censored (0) and censored (1) areas.
                     // The 0.01 lower bound prevents feathering from extending too far
                     // into the non-censored area, keeping the edge crisp.
+                    mask = tex2D(_CensorMask, i.uv).r;
                     mask = smoothstep(0.01, 1.0, mask);
                 }
                 else
                 {
-                    // Hard edges: Use ceil to create a sharp, blocky edge that perfectly
-                    // aligns with the pixel grid of the mask. This is useful for a more
-                    // retro, aliased look.
-                    mask = ceil(mask);
+                    // For hard, pixel-perfect edges, sample the mask using the same
+                    // pixelated UV coordinates used for the color. This ensures the
+                    // mask's boundary aligns perfectly with the pixel blocks,
+                    // creating a clean, retro look without harsh, sub-pixel aliasing.
+                    mask = tex2D(_CensorMask, pixelatedUV).r;
                 }
 
                 // Linearly interpolate between the original and pixelated colors


### PR DESCRIPTION
This commit addresses two visual artifacts in the CensorEffect:

1. Occlusion was not working correctly because the secondary censor camera's properties were not fully synchronized with the main camera. Specifically, the projection matrix was missing. This has been fixed by replacing the manual property copy with `Camera.CopyFrom()`, ensuring all properties are correctly aligned. A depth buffer has also been added to the mask's render texture to prevent z-fighting between censored objects.

2. When Anti-Aliasing was disabled, the effect's border was a harsh, aliased line. This has been changed to produce a clean, pixel-aligned border. The shader now samples the censor mask using the same pixelated UV coordinates as the effect color, ensuring the mask's boundary aligns perfectly with the pixel blocks.