### PR TITLE
Fix: Correct occlusion and non-AA borders

### DIFF
--- a/Runtime/CensorEffect.cs
+++ b/Runtime/CensorEffect.cs
@@ -79,12 +79,16 @@ namespace CensorEffect.Runtime
 
             UpdateMaterialProperties();
 
-            var maskDescriptor = new RenderTextureDescriptor(source.width, source.height, RenderTextureFormat.R8, 0)
+            var maskDescriptor = new RenderTextureDescriptor(source.width, source.height, RenderTextureFormat.R8, 16)
             {
                 msaaSamples = EnableAntiAliasing ? GetMsaaSampleCount(source) : 1
             };
             var censorMask = RenderTexture.GetTemporary(maskDescriptor);
 
+            // Explicitly set the main camera's depth texture as a global shader
+            // variable. This is more reliable than relying on Unity to automatically
+            // bind _CameraDepthTexture during a manual RenderWithShader call.
+            Graphics.SetGlobalTexture("_CensorDepthTexture", BuiltinRenderTextureType.Depth);
             RenderCensorMask(censorMask);
 
             RenderTexture processedMask;
@@ -197,21 +201,19 @@ namespace CensorEffect.Runtime
         {
             if (source == null || target == null) return;
 
-            // Manually copy essential properties instead of using Camera.CopyFrom()
-            target.transform.position = source.transform.position;
-            target.transform.rotation = source.transform.rotation;
-            target.fieldOfView = source.fieldOfView;
-            target.nearClipPlane = source.nearClipPlane;
-            target.farClipPlane = source.farClipPlane;
-            target.orthographic = source.orthographic;
-            target.orthographicSize = source.orthographicSize;
-            target.aspect = source.aspect;
+            // Copy all properties from the source camera, which is more robust than
+            // manually setting each property. This ensures properties like the
+            // projection matrix are correctly synchronized, which is crucial for
+            // depth buffer sampling.
+            target.CopyFrom(source);
 
+            // Override specific properties for the censor camera's unique role.
             target.depthTextureMode |= DepthTextureMode.Depth;
             target.cullingMask = CensorLayer;
             target.clearFlags = CameraClearFlags.SolidColor;
             target.backgroundColor = Color.clear;
             target.useOcclusionCulling = false;
+            target.allowMSAA = true; // Ensure MSAA is explicitly allowed
         }
 
         private int GetMsaaSampleCount(RenderTexture source)

--- a/Runtime/Resources/CensorEffect.shader
+++ b/Runtime/Resources/CensorEffect.shader
@@ -66,25 +66,25 @@ Shader "Hidden/CensorEffect"
                 // 3. Sample the original texture at the snapped UV to get a blocky, pixelated color.
                 fixed4 pixelatedColor = tex2D(_MainTex, pixelatedUV);
 
-                // Sample the pre-processed (MSAA-resolved and dilated) censor mask.
-                // We only need the red channel since it's an R8 texture.
-                fixed mask = tex2D(_CensorMask, i.uv).r;
-
-                // Process the mask edge based on the anti-aliasing setting.
+                // Sample the censor mask. The method depends on the anti-aliasing setting.
+                fixed mask;
                 if (_AntiAliasing > 0.5)
                 {
-                    // Soft edges: Use smoothstep to create a soft, anti-aliased transition
+                    // For soft edges, sample the mask at the fragment's native UV.
+                    // Then, use smoothstep to create a soft, anti-aliased transition
                     // between the non-censored (0) and censored (1) areas.
                     // The 0.01 lower bound prevents feathering from extending too far
                     // into the non-censored area, keeping the edge crisp.
+                    mask = tex2D(_CensorMask, i.uv).r;
                     mask = smoothstep(0.01, 1.0, mask);
                 }
                 else
                 {
-                    // Hard edges: Use ceil to create a sharp, blocky edge that perfectly
-                    // aligns with the pixel grid of the mask. This is useful for a more
-                    // retro, aliased look.
-                    mask = ceil(mask);
+                    // For hard, pixel-perfect edges, sample the mask using the same
+                    // pixelated UV coordinates used for the color. This ensures the
+                    // mask's boundary aligns perfectly with the pixel blocks,
+                    // creating a clean, retro look without harsh, sub-pixel aliasing.
+                    mask = tex2D(_CensorMask, pixelatedUV).r;
                 }
 
                 // Linearly interpolate between the original and pixelated colors

--- a/Runtime/Resources/CensorMask.shader
+++ b/Runtime/Resources/CensorMask.shader
@@ -30,9 +30,9 @@ Shader "Hidden/CensorMask"
 
             #include "UnityCG.cginc"
 
-            // The main camera's depth texture, automatically provided by Unity
-            // when camera.depthTextureMode is set appropriately.
-            sampler2D _CameraDepthTexture;
+            // The main camera's depth texture, provided manually from the C# script
+            // to ensure it's available during the manual camera render.
+            sampler2D _CensorDepthTexture;
 
             // Input mesh data (vertex position).
             struct appdata
@@ -62,7 +62,7 @@ Shader "Hidden/CensorMask"
                 // This entire block is compiled out if _OCCLUSION_ON is not defined.
                 #if _OCCLUSION_ON
                     // Sample the main camera's depth texture at the fragment's screen position.
-                    float sceneDepth = SAMPLE_DEPTH_TEXTURE_PROJ(_CameraDepthTexture, UNITY_PROJ_COORD(i.screenPos));
+                    float sceneDepth = SAMPLE_DEPTH_TEXTURE_PROJ(_CensorDepthTexture, UNITY_PROJ_COORD(i.screenPos));
                     // The raw depth value is non-linear. Convert it to linear eye-space depth for a correct comparison.
                     float sceneLinearEyeDepth = LinearEyeDepth(sceneDepth);
                     // The current fragment's distance from the camera (w component of screenPos). Already linear.


### PR DESCRIPTION
This commit provides two main fixes to the CensorEffect:

1.  **Pixel-Perfect Non-Anti-Aliased Borders:** When Anti-Aliasing is disabled, the effect's border now aligns perfectly with the pixelation grid. This is achieved by sampling the censor mask with the same pixelated UV coordinates used for the effect's color, creating a clean, retro look.

2.  **Robust Occlusion:** Fixes a bug where censored objects would render through foreground geometry. The issue was that the censor mask shader could not reliably access the main camera's depth buffer during its manual render. This is now solved by explicitly passing the main camera's depth texture as a global shader variable (`_CensorDepthTexture`) just before the mask is rendered. This ensures the depth comparison for occlusion is always correct.