### PR TITLE
Fix compilation error in CensorEffect.cs

### DIFF
--- a/Editor/CensorEffectEditor.cs
+++ b/Editor/CensorEffectEditor.cs
@@ -1,23 +1,24 @@
+using UnityEditor;
 using UnityEditor.Rendering.PostProcessing;
 using UnityEngine.Rendering.PostProcessing;
 
 [PostProcessEditor(typeof(CensorEffect))]
 public sealed class CensorEffectEditor : PostProcessEffectEditor<CensorEffect>
 {
-    private SerializedParameterOverride _censorLayer;
+    private SerializedProperty _censorLayer;
     private SerializedParameterOverride _pixelSize;
     private SerializedParameterOverride _hardEdges;
 
     public override void OnEnable()
     {
-        _censorLayer = FindParameterOverride(x => x.censorLayer);
+        _censorLayer = serializedObject.FindProperty("censorLayer");
         _pixelSize = FindParameterOverride(x => x.pixelSize);
         _hardEdges = FindParameterOverride(x => x.hardEdges);
     }
 
     public override void OnInspectorGUI()
     {
-        PropertyField(_censorLayer);
+        EditorGUILayout.PropertyField(_censorLayer);
         PropertyField(_pixelSize);
         PropertyField(_hardEdges);
     }

--- a/Runtime/CensorEffect.cs
+++ b/Runtime/CensorEffect.cs
@@ -7,7 +7,7 @@ using UnityEngine.Rendering.PostProcessing;
 public sealed class CensorEffect : PostProcessEffectSettings
 {
     [Tooltip("The layer(s) to apply the censor effect to.")]
-    public LayerMaskParameter censorLayer = new LayerMaskParameter { value = 0 };
+    public LayerMask censorLayer;
 
     [Range(1, 256), Tooltip("The size of the pixelation blocks.")]
     public IntParameter pixelSize = new IntParameter { value = 50 };
@@ -46,7 +46,7 @@ public sealed class CensorEffectRenderer : PostProcessEffectRenderer<CensorEffec
         sheet.properties.SetInt("_HardEdges", settings.hardEdges ? 1 : 0);
 
         // Render the objects on the specified layer to a separate render texture
-        _censorLayerMask = settings.censorLayer.value;
+        _censorLayerMask = settings.censorLayer;
         if (_censorLayerMask != 0)
         {
             // Match the camera settings


### PR DESCRIPTION
The type `LayerMaskParameter` is not available in recent versions of the Unity Post-Processing Stack, causing a compilation error.

This commit replaces `LayerMaskParameter` with the standard `LayerMask` type and updates the editor script to correctly display the `LayerMask` field in the inspector.