### PR TITLE
Modernize CensorEffect package

### DIFF
--- a/Editor/CensorEffectEditor.cs
+++ b/Editor/CensorEffectEditor.cs
@@ -1,23 +1,24 @@
+using UnityEditor;
 using UnityEditor.Rendering.PostProcessing;
 using UnityEngine.Rendering.PostProcessing;
 
 [PostProcessEditor(typeof(CensorEffect))]
 public sealed class CensorEffectEditor : PostProcessEffectEditor<CensorEffect>
 {
-    private SerializedParameterOverride _censorLayer;
+    private SerializedProperty _censorLayer;
     private SerializedParameterOverride _pixelSize;
     private SerializedParameterOverride _hardEdges;
 
     public override void OnEnable()
     {
-        _censorLayer = FindParameterOverride(x => x.censorLayer);
+        _censorLayer = serializedObject.FindProperty("censorLayer");
         _pixelSize = FindParameterOverride(x => x.pixelSize);
         _hardEdges = FindParameterOverride(x => x.hardEdges);
     }
 
     public override void OnInspectorGUI()
     {
-        PropertyField(_censorLayer);
+        EditorGUILayout.PropertyField(_censorLayer);
         PropertyField(_pixelSize);
         PropertyField(_hardEdges);
     }

--- a/Runtime/CensorEffect.cs
+++ b/Runtime/CensorEffect.cs
@@ -7,7 +7,7 @@ using UnityEngine.Rendering.PostProcessing;
 public sealed class CensorEffect : PostProcessEffectSettings
 {
     [Tooltip("The layer(s) to apply the censor effect to.")]
-    public LayerMaskParameter censorLayer = new LayerMaskParameter { value = 0 };
+    public LayerMask censorLayer;
 
     [Range(1, 256), Tooltip("The size of the pixelation blocks.")]
     public IntParameter pixelSize = new IntParameter { value = 50 };
@@ -43,10 +43,11 @@ public sealed class CensorEffectRenderer : PostProcessEffectRenderer<CensorEffec
         // Setup the property sheet
         var sheet = context.propertySheets.Get(_censorShader);
         sheet.properties.SetFloat("_PixelSize", settings.pixelSize);
-        sheet.properties.SetInt("_HardEdges", settings.hardEdges ? 1 : 0);
+        // Use SetFloat for _HardEdges as it's a half in the shader now
+        sheet.properties.SetFloat("_HardEdges", settings.hardEdges ? 1.0f : 0.0f);
 
         // Render the objects on the specified layer to a separate render texture
-        _censorLayerMask = settings.censorLayer.value;
+        _censorLayerMask = settings.censorLayer;
         if (_censorLayerMask != 0)
         {
             // Match the camera settings

--- a/Shaders/CensorShader.shader
+++ b/Shaders/CensorShader.shader
@@ -1,7 +1,20 @@
 Shader "Hidden/Custom/CensorShader"
 {
+    Properties
+    {
+        // This property is not used in the shader, but is required for the post-processing stack
+        _MainTex ("Texture", 2D) = "white" {}
+        // The mask texture that defines the areas to be pixelated
+        _CensorMaskTex ("Censor Mask", 2D) = "black" {}
+        // The size of the pixelation blocks
+        _PixelSize ("Pixel Size", Float) = 50.0
+        // A toggle for hard edges (0 = soft, 1 = hard)
+        _HardEdges ("Hard Edges", Range(0, 1)) = 0
+    }
+
     SubShader
     {
+        // This pass is a fullscreen post-processing effect
         Cull Off ZWrite Off ZTest Always
 
         Pass
@@ -11,42 +24,44 @@ Shader "Hidden/Custom/CensorShader"
                 #pragma vertex VertDefault
                 #pragma fragment Frag
 
+                // Include the standard library from the Post-Processing Stack
                 #include "Packages/com.unity.post-processing/PostProcessing/Shaders/StdLib.hlsl"
 
+                // Texture samplers
                 TEXTURE2D_SAMPLER2D(_CensorMaskTex, sampler_CensorMaskTex);
 
+                // Shader properties
                 float _PixelSize;
-                int _HardEdges;
+                half _HardEdges; // Use half for a 0-1 range value
 
-                float4 Frag(VaryingsDefault i) : SV_Target
+                // Fragment shader
+                half4 Frag(VaryingsDefault i) : SV_Target
                 {
+                    // Get the screen space UV coordinates
                     float2 screen_uv = i.texcoord;
-                    float4 original_color = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, screen_uv);
 
-                    if (_HardEdges == 1)
-                    {
-                        // Hard Edges: Pixelate only if the current pixel is within the mask.
-                        // This creates a sharp silhouette.
-                        float mask = SAMPLE_TEXTURE2D(_CensorMaskTex, sampler_CensorMaskTex, screen_uv).r;
-                        if (mask > 0)
-                        {
-                            float2 pixelated_uv = floor(screen_uv * _ScreenParams.xy / _PixelSize) * _PixelSize / _ScreenParams.xy;
-                            return SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, pixelated_uv);
-                        }
-                        return original_color;
-                    }
-                    else
-                    {
-                        // Soft Edges: Pixelate if the source of the pixelation is within the mask.
-                        // This allows the pixelation effect to "bleed" over the edges of the mask.
-                        float2 pixelated_uv = floor(screen_uv * _ScreenParams.xy / _PixelSize) * _PixelSize / _ScreenParams.xy;
-                        float source_mask = SAMPLE_TEXTURE2D(_CensorMaskTex, sampler_CensorMaskTex, pixelated_uv).r;
-                        if (source_mask > 0)
-                        {
-                            return SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, pixelated_uv);
-                        }
-                        return original_color;
-                    }
+                    // Calculate the UV coordinates for the pixelated version of the screen
+                    float2 pixelated_uv = floor(screen_uv * _ScreenParams.xy / _PixelSize) * _PixelSize / _ScreenParams.xy;
+
+                    // Sample the original color and the pixelated color
+                    half4 original_color = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, screen_uv);
+                    half4 pixelated_color = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, pixelated_uv);
+
+                    // Sample the mask at the current pixel's UV (for hard edges)
+                    half hard_mask = SAMPLE_TEXTURE2D(_CensorMaskTex, sampler_CensorMaskTex, screen_uv).r;
+
+                    // Sample the mask at the pixelated UV (for soft edges)
+                    half soft_mask = SAMPLE_TEXTURE2D(_CensorMaskTex, sampler_CensorMaskTex, pixelated_uv).r;
+
+                    // Linearly interpolate between the soft and hard mask based on the _HardEdges uniform.
+                    // If _HardEdges is 0, we use soft_mask. If it's 1, we use hard_mask.
+                    half final_mask = lerp(soft_mask, hard_mask, _HardEdges);
+
+                    // Linearly interpolate between the original color and the pixelated color based on the final mask.
+                    // If the mask is 0, we use the original color. If it's 1, we use the pixelated color.
+                    half4 final_color = lerp(original_color, pixelated_color, final_mask);
+
+                    return final_color;
                 }
 
             ENDCGPROGRAM


### PR DESCRIPTION
This commit rewrites the CensorEffect package to follow modern standards for Unity 2019+ and the Built-in Render Pipeline with Post-Processing Stack v2.

- The shader (`CensorShader.shader`) has been rewritten to be more performant and readable. It now uses a branchless approach and `half` precision for color calculations.
- The C# scripts (`CensorEffect.cs` and `CensorEffectEditor.cs`) have been reviewed and updated to align with the new shader and modern practices.