### PR TITLE
Feat: Modernize CensorEffect package and fix compilation errors

### DIFF
--- a/Editor/ineedmypills.censor.editor.asmdef
+++ b/Editor/ineedmypills.censor.editor.asmdef
@@ -1,6 +1,7 @@
 {
   "name": "ineedmypills.censor.editor",
   "references": [
+    "Unity.Postprocessing.Runtime",
     "Unity.Postprocessing.Editor",
     "ineedmypills.censor.runtime"
   ],

--- a/Runtime/CensorEffect.cs
+++ b/Runtime/CensorEffect.cs
@@ -7,7 +7,7 @@ using UnityEngine.Rendering.PostProcessing;
 public sealed class CensorEffect : PostProcessEffectSettings
 {
     [Tooltip("The layer(s) to apply the censor effect to.")]
-    public LayerMaskParameter censorLayer = new LayerMaskParameter { value = 0 };
+    public LayerMaskParameter censorLayer = new LayerMaskParameter();
 
     [Range(1, 256), Tooltip("The size of the pixelation blocks.")]
     public IntParameter pixelSize = new IntParameter { value = 50 };

--- a/Runtime/LayerMaskParameter.cs
+++ b/Runtime/LayerMaskParameter.cs
@@ -1,0 +1,12 @@
+using System;
+using UnityEngine;
+using UnityEngine.Rendering.PostProcessing;
+
+[Serializable]
+public sealed class LayerMaskParameter : ParameterOverride<LayerMask>
+{
+    public override void Interp(LayerMask from, LayerMask to, float t)
+    {
+        value = t < 1 ? from : to;
+    }
+}

--- a/Shaders/CensorShader.shader
+++ b/Shaders/CensorShader.shader
@@ -1,7 +1,20 @@
 Shader "Hidden/Custom/CensorShader"
 {
+    Properties
+    {
+        // This property is not used in the shader, but is required for the post-processing stack
+        _MainTex ("Texture", 2D) = "white" {}
+        // The mask texture that defines the areas to be pixelated
+        _CensorMaskTex ("Censor Mask", 2D) = "black" {}
+        // The size of the pixelation blocks
+        _PixelSize ("Pixel Size", Float) = 50.0
+        // A toggle for hard edges (0 = soft, 1 = hard)
+        _HardEdges ("Hard Edges", Range(0, 1)) = 0
+    }
+
     SubShader
     {
+        // This pass is a fullscreen post-processing effect
         Cull Off ZWrite Off ZTest Always
 
         Pass
@@ -11,42 +24,44 @@ Shader "Hidden/Custom/CensorShader"
                 #pragma vertex VertDefault
                 #pragma fragment Frag
 
+                // Include the standard library from the Post-Processing Stack
                 #include "Packages/com.unity.post-processing/PostProcessing/Shaders/StdLib.hlsl"
 
+                // Texture samplers
                 TEXTURE2D_SAMPLER2D(_CensorMaskTex, sampler_CensorMaskTex);
 
+                // Shader properties
                 float _PixelSize;
-                int _HardEdges;
+                half _HardEdges; // Use half for a 0-1 range value
 
-                float4 Frag(VaryingsDefault i) : SV_Target
+                // Fragment shader
+                half4 Frag(VaryingsDefault i) : SV_Target
                 {
+                    // Get the screen space UV coordinates
                     float2 screen_uv = i.texcoord;
-                    float4 original_color = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, screen_uv);
 
-                    if (_HardEdges == 1)
-                    {
-                        // Hard Edges: Pixelate only if the current pixel is within the mask.
-                        // This creates a sharp silhouette.
-                        float mask = SAMPLE_TEXTURE2D(_CensorMaskTex, sampler_CensorMaskTex, screen_uv).r;
-                        if (mask > 0)
-                        {
-                            float2 pixelated_uv = floor(screen_uv * _ScreenParams.xy / _PixelSize) * _PixelSize / _ScreenParams.xy;
-                            return SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, pixelated_uv);
-                        }
-                        return original_color;
-                    }
-                    else
-                    {
-                        // Soft Edges: Pixelate if the source of the pixelation is within the mask.
-                        // This allows the pixelation effect to "bleed" over the edges of the mask.
-                        float2 pixelated_uv = floor(screen_uv * _ScreenParams.xy / _PixelSize) * _PixelSize / _ScreenParams.xy;
-                        float source_mask = SAMPLE_TEXTURE2D(_CensorMaskTex, sampler_CensorMaskTex, pixelated_uv).r;
-                        if (source_mask > 0)
-                        {
-                            return SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, pixelated_uv);
-                        }
-                        return original_color;
-                    }
+                    // Calculate the UV coordinates for the pixelated version of the screen
+                    float2 pixelated_uv = floor(screen_uv * _ScreenParams.xy / _PixelSize) * _PixelSize / _ScreenParams.xy;
+
+                    // Sample the original color and the pixelated color
+                    half4 original_color = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, screen_uv);
+                    half4 pixelated_color = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, pixelated_uv);
+
+                    // Sample the mask at the current pixel's UV (for hard edges)
+                    half hard_mask = SAMPLE_TEXTURE2D(_CensorMaskTex, sampler_CensorMaskTex, screen_uv).r;
+
+                    // Sample the mask at the pixelated UV (for soft edges)
+                    half soft_mask = SAMPLE_TEXTURE2D(_CensorMaskTex, sampler_CensorMaskTex, pixelated_uv).r;
+
+                    // Linearly interpolate between the soft and hard mask based on the _HardEdges uniform.
+                    // If _HardEdges is 0, we use soft_mask. If it's 1, we use hard_mask.
+                    half final_mask = lerp(soft_mask, hard_mask, _HardEdges);
+
+                    // Linearly interpolate between the original color and the pixelated color based on the final mask.
+                    // If the mask is 0, we use the original color. If it's 1, we use the pixelated color.
+                    half4 final_color = lerp(original_color, pixelated_color, final_mask);
+
+                    return final_color;
                 }
 
             ENDCGPROGRAM


### PR DESCRIPTION
This commit rewrites the CensorEffect package to follow modern standards for Unity 2019+ and the Built-in Render Pipeline with Post-Processing Stack v2. It also fixes a series of compilation errors related to assembly definitions and property drawing in the editor.

- The shader (`CensorShader.shader`) has been rewritten to be more performant and readable. It now uses a branchless approach and `half` precision for color calculations.
- A custom `LayerMaskParameter` class has been created to properly integrate with the Post-Processing Stack's parameter system.
- The C# scripts (`CensorEffect.cs` and `CensorEffectEditor.cs`) have been updated to use the new `LayerMaskParameter` and align with modern practices.
- The assembly definition files (`.asmdef`) have been updated to include the correct references to the Post-Processing Stack assemblies.