### PR TITLE
Fix(CensorEffect): Correctly access LayerMask value

### DIFF
--- a/Runtime/CensorEffect.cs
+++ b/Runtime/CensorEffect.cs
@@ -47,7 +47,7 @@ public sealed class CensorEffectRenderer : PostProcessEffectRenderer<CensorEffec
         sheet.properties.SetFloat("_HardEdges", settings.hardEdges ? 1.0f : 0.0f);
 
         // Render the objects on the specified layer to a separate render texture
-        _censorLayerMask = settings.censorLayer;
+        _censorLayerMask = settings.censorLayer.value;
         if (_censorLayerMask != 0)
         {
             // Match the camera settings


### PR DESCRIPTION
The previous code attempted to assign a `LayerMaskParameter` directly to an `int` variable, causing a CS0029 compilation error.

This change fixes the issue by accessing the `.value` property of the `LayerMaskParameter`, which provides the underlying `LayerMask` that can be implicitly converted to an `int`.