### PR TITLE
Fix(PostProcessing): Resolve compilation errors in CensorEffect

### DIFF
--- a/Editor/CensorEffectEditor.cs
+++ b/Editor/CensorEffectEditor.cs
@@ -5,20 +5,20 @@ using UnityEngine.Rendering.PostProcessing;
 [PostProcessEditor(typeof(CensorEffect))]
 public sealed class CensorEffectEditor : PostProcessEffectEditor<CensorEffect>
 {
-    private SerializedProperty _censorLayer;
+    private SerializedParameterOverride _censorLayer;
     private SerializedParameterOverride _pixelSize;
     private SerializedParameterOverride _hardEdges;
 
     public override void OnEnable()
     {
-        _censorLayer = serializedObject.FindProperty("censorLayer");
+        _censorLayer = FindParameterOverride(x => x.censorLayer);
         _pixelSize = FindParameterOverride(x => x.pixelSize);
         _hardEdges = FindParameterOverride(x => x.hardEdges);
     }
 
     public override void OnInspectorGUI()
     {
-        EditorGUILayout.PropertyField(_censorLayer);
+        PropertyField(_censorLayer);
         PropertyField(_pixelSize);
         PropertyField(_hardEdges);
     }

--- a/Runtime/CensorEffect.cs
+++ b/Runtime/CensorEffect.cs
@@ -47,7 +47,7 @@ public sealed class CensorEffectRenderer : PostProcessEffectRenderer<CensorEffec
         sheet.properties.SetFloat("_HardEdges", settings.hardEdges ? 1.0f : 0.0f);
 
         // Render the objects on the specified layer to a separate render texture
-        _censorLayerMask = settings.censorLayer;
+        _censorLayerMask = settings.censorLayer.value;
         if (_censorLayerMask != 0)
         {
             // Match the camera settings


### PR DESCRIPTION
This commit addresses two separate compilation errors in the CensorEffect post-processing feature.

1.  In `Runtime/CensorEffect.cs`, a type mismatch occurred when assigning a `LayerMaskParameter` to an `int`. This is resolved by accessing the `.value` property of the parameter to get the underlying integer value of the layer mask.

2.  In `Editor/CensorEffectEditor.cs`, the code was using an outdated API (`serializedObject.FindProperty`) to access the `censorLayer` property. This has been updated to use the modern `FindParameterOverride` method, and the `_censorLayer` field has been changed from `SerializedProperty` to `SerializedParameterOverride` to match. The GUI drawing call was also updated from `EditorGUILayout.PropertyField` to the appropriate `PropertyField` helper.