### PR TITLE
Fix(PostProcessing): Resolve compilation and runtime errors in Censor…

### DIFF
--- a/Editor/CensorEffectEditor.cs
+++ b/Editor/CensorEffectEditor.cs
@@ -5,20 +5,20 @@ using UnityEngine.Rendering.PostProcessing;
 [PostProcessEditor(typeof(CensorEffect))]
 public sealed class CensorEffectEditor : PostProcessEffectEditor<CensorEffect>
 {
-    private SerializedProperty _censorLayer;
+    private SerializedParameterOverride _censorLayer;
     private SerializedParameterOverride _pixelSize;
     private SerializedParameterOverride _hardEdges;
 
     public override void OnEnable()
     {
-        _censorLayer = serializedObject.FindProperty("censorLayer");
+        _censorLayer = FindParameterOverride(x => x.censorLayer);
         _pixelSize = FindParameterOverride(x => x.pixelSize);
         _hardEdges = FindParameterOverride(x => x.hardEdges);
     }
 
     public override void OnInspectorGUI()
     {
-        EditorGUILayout.PropertyField(_censorLayer);
+        PropertyField(_censorLayer);
         PropertyField(_pixelSize);
         PropertyField(_hardEdges);
     }

--- a/Runtime/CensorEffect.cs
+++ b/Runtime/CensorEffect.cs
@@ -38,7 +38,11 @@ public sealed class CensorEffectRenderer : PostProcessEffectRenderer<CensorEffec
 
     public override void Render(PostProcessRenderContext context)
     {
-        if (_censorShader == null) return;
+        if (_censorShader == null)
+        {
+            context.command.BlitFullscreenTriangle(context.source, context.destination);
+            return;
+        }
 
         // Setup the property sheet
         var sheet = context.propertySheets.Get(_censorShader);
@@ -47,7 +51,7 @@ public sealed class CensorEffectRenderer : PostProcessEffectRenderer<CensorEffec
         sheet.properties.SetFloat("_HardEdges", settings.hardEdges ? 1.0f : 0.0f);
 
         // Render the objects on the specified layer to a separate render texture
-        _censorLayerMask = settings.censorLayer;
+        _censorLayerMask = settings.censorLayer.value;
         if (_censorLayerMask != 0)
         {
             // Match the camera settings


### PR DESCRIPTION
…Effect

This commit addresses several issues in the CensorEffect post-processing feature to make it functional.

1.  **Runtime Fix:** The Render method in `Runtime/CensorEffect.cs` would cause the entire post-processing stack to fail if the effect's shader was not found. This has been fixed by adding a fallback to blit the source to the destination, ensuring the render chain is never broken. This resolves the bug where the effect would disable all other post-processing effects.

2.  **Compilation Fix 1:** A type mismatch in `Runtime/CensorEffect.cs` occurred when assigning a `LayerMaskParameter` to an `int`. This is resolved by accessing the `.value` property of the parameter to get the underlying integer value of the layer mask.

3.  **Compilation Fix 2:** The editor script `Editor/CensorEffectEditor.cs` was using an outdated API (`serializedObject.FindProperty`) for a `ParameterOverride` type. This has been updated to use the modern `FindParameterOverride` method and `PropertyField` helper, resolving the compilation error in the editor script.