### PR TITLE
Fix(CensorEffect): Overhaul effect to resolve bugs and improve implem…

### DIFF
--- a/Editor/CensorEffectEditor.cs
+++ b/Editor/CensorEffectEditor.cs
@@ -5,20 +5,20 @@ using UnityEngine.Rendering.PostProcessing;
 [PostProcessEditor(typeof(CensorEffect))]
 public sealed class CensorEffectEditor : PostProcessEffectEditor<CensorEffect>
 {
-    private SerializedProperty _censorLayer;
+    private SerializedParameterOverride _censorLayer;
     private SerializedParameterOverride _pixelSize;
     private SerializedParameterOverride _hardEdges;
 
     public override void OnEnable()
     {
-        _censorLayer = serializedObject.FindProperty("censorLayer");
+        _censorLayer = FindParameterOverride(x => x.censorLayer);
         _pixelSize = FindParameterOverride(x => x.pixelSize);
         _hardEdges = FindParameterOverride(x => x.hardEdges);
     }
 
     public override void OnInspectorGUI()
     {
-        EditorGUILayout.PropertyField(_censorLayer);
+        PropertyField(_censorLayer);
         PropertyField(_pixelSize);
         PropertyField(_hardEdges);
     }

--- a/Runtime/CensorEffect.cs
+++ b/Runtime/CensorEffect.cs
@@ -19,6 +19,7 @@ public sealed class CensorEffect : PostProcessEffectSettings
 public sealed class CensorEffectRenderer : PostProcessEffectRenderer<CensorEffect>
 {
     private Shader _censorShader;
+    private Shader _whiteMaskShader;
     private int _censorLayerMask;
     private Camera _censorCamera;
     private RenderTexture _censorLayerTexture;
@@ -26,6 +27,7 @@ public sealed class CensorEffectRenderer : PostProcessEffectRenderer<CensorEffec
     public override void Init()
     {
         _censorShader = Shader.Find("Hidden/Custom/CensorShader");
+        _whiteMaskShader = Shader.Find("Hidden/Custom/WhiteMask");
 
         // Create a temporary camera for rendering the censor layer
         var go = new GameObject("Censor Camera")
@@ -38,44 +40,48 @@ public sealed class CensorEffectRenderer : PostProcessEffectRenderer<CensorEffec
 
     public override void Render(PostProcessRenderContext context)
     {
-        if (_censorShader == null) return;
+        // If the main shader is missing, just pass the texture through to avoid breaking the chain.
+        if (_censorShader == null)
+        {
+            context.command.BlitFullscreenTriangle(context.source, context.destination);
+            return;
+        }
 
-        // Setup the property sheet
         var sheet = context.propertySheets.Get(_censorShader);
         sheet.properties.SetFloat("_PixelSize", settings.pixelSize);
-        // Use SetFloat for _HardEdges as it's a half in the shader now
         sheet.properties.SetFloat("_HardEdges", settings.hardEdges ? 1.0f : 0.0f);
 
-        // Render the objects on the specified layer to a separate render texture
-        _censorLayerMask = settings.censorLayer;
-        if (_censorLayerMask != 0)
+        _censorLayerMask = settings.censorLayer.value;
+
+        // Only render the mask if a layer is selected and we have the shader for it
+        if (_censorLayerMask != 0 && _whiteMaskShader != null)
         {
-            // Match the camera settings
             _censorCamera.CopyFrom(context.camera);
             _censorCamera.cullingMask = _censorLayerMask;
             _censorCamera.clearFlags = CameraClearFlags.SolidColor;
             _censorCamera.backgroundColor = Color.clear;
 
-            // Create a render texture for the mask
             _censorLayerTexture = RenderTexture.GetTemporary(context.width, context.height, 0, RenderTextureFormat.R8);
             _censorCamera.targetTexture = _censorLayerTexture;
-            _censorCamera.Render();
+
+            // Render the objects with a solid white shader to create the mask
+            _censorCamera.RenderWithShader(_whiteMaskShader, "RenderType");
 
             sheet.properties.SetTexture("_CensorMaskTex", _censorLayerTexture);
         }
         else
         {
-            // If no layer is selected, use a blank texture
+            // If no layer is selected, or the mask shader is missing, use a blank texture
             sheet.properties.SetTexture("_CensorMaskTex", Texture2D.blackTexture);
         }
 
-        // Apply the effect
         context.command.BlitFullscreenTriangle(context.source, context.destination, sheet, 0);
 
-        // Cleanup
+        // Cleanup the temporary texture
         if (_censorLayerTexture != null)
         {
             RenderTexture.ReleaseTemporary(_censorLayerTexture);
+            _censorLayerTexture = null; // Set to null to prevent double release
         }
     }
 

--- a/Shaders/WhiteMask.shader
+++ b/Shaders/WhiteMask.shader
@@ -1,0 +1,37 @@
+Shader "Hidden/Custom/WhiteMask"
+{
+    SubShader
+    {
+        Tags { "RenderType"="Opaque" }
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+            };
+
+            struct v2f
+            {
+                float4 pos : SV_POSITION;
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                o.pos = UnityObjectToClipPos(v.vertex);
+                return o;
+            }
+
+            fixed4 frag(v2f i) : SV_Target
+            {
+                return fixed4(1, 1, 1, 1);
+            }
+            ENDCGPROGRAM
+        }
+    }
+}

--- a/Shaders/WhiteMask.shader.meta
+++ b/Shaders/WhiteMask.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 9a4abc51f91c2df4fbb2f04984537e45
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
…entation

This commit provides a complete overhaul of the CensorEffect to fix a series of compilation and runtime issues and to improve the core implementation for more robust behavior.

The following issues were addressed:

1.  **Runtime Bug - Broken Render Chain:** The effect would break the post-processing render chain if its shader was not found, causing all subsequent effects to fail. This was fixed by adding a fallback blit to pass the image through, ensuring the chain remains intact.

2.  **Runtime Bug - Ineffective Masking:** The core logic for generating the censorship mask was flawed. It rendered objects with their original materials, meaning dark objects would not create a visible mask, and the effect would fail. This has been completely reworked. A new `WhiteMask.shader` has been introduced to render objects as solid white, and the rendering logic now uses `RenderWithShader` to generate a correct, high-contrast mask.

3.  **Compilation Error - Type Mismatch:** A CS0029 error in `CensorEffect.cs` was caused by assigning a `LayerMaskParameter` directly to an `int`. This was fixed by accessing the `.value` property.

4.  **Compilation Error - Deprecated API:** A CS0103 error in `CensorEffectEditor.cs` was caused by using the outdated `serializedObject.FindProperty` API for a `ParameterOverride`. This was updated to use the modern `FindParameterOverride` method and the `PropertyField` helper.

5.  **Robustness:** The cleanup logic for the temporary `RenderTexture` used for the mask was improved by nulling out the reference after release to prevent potential double-releasing issues.