### PR TITLE
Fix pixelation effect and improve robustness

### DIFF
--- a/Resources/CensorShader.shader
+++ b/Resources/CensorShader.shader
@@ -47,19 +47,22 @@ Shader "Hidden/CensorEffect/Censor"
             fixed4 frag (v2f i) : SV_Target
             {
                 fixed4 originalColor = tex2D(_MainTex, i.uv);
-                float mask = tex2D(_CensorMaskTex, i.uv).r;
+                float2 pixelatedUV = floor(i.uv * _ScreenParams.xy / _PixelSize) * _PixelSize / _ScreenParams.xy;
 
-                if (mask > 0.1)
+                if (_HardEdges > 0.5)
                 {
-                    float2 pixelatedUV = floor(i.uv * _ScreenParams.xy / _PixelSize) * _PixelSize / _ScreenParams.xy;
-                    fixed4 pixelatedColor = tex2D(_MainTex, pixelatedUV);
-
-                    if (_HardEdges > 0.5)
+                    float pixelatedMask = tex2D(_CensorMaskTex, pixelatedUV).r;
+                    if (pixelatedMask > 0.1)
                     {
-                        return pixelatedColor;
+                        return tex2D(_MainTex, pixelatedUV);
                     }
-                    else
+                }
+                else
+                {
+                    float mask = tex2D(_CensorMaskTex, i.uv).r;
+                    if (mask > 0.1)
                     {
+                        fixed4 pixelatedColor = tex2D(_MainTex, pixelatedUV);
                         return lerp(originalColor, pixelatedColor, mask);
                     }
                 }

--- a/Resources/WhiteMask.shader
+++ b/Resources/WhiteMask.shader
@@ -10,18 +10,35 @@ Shader "Hidden/CensorEffect/WhiteMask"
             #pragma fragment frag
             #include "UnityCG.cginc"
 
+            sampler2D _CameraDepthTexture;
+
             struct appdata {
                 float4 vertex : POSITION;
             };
+
             struct v2f {
                 float4 vertex : SV_POSITION;
+                float4 screenPos : TEXCOORD0;
             };
+
             v2f vert (appdata v) {
                 v2f o;
                 o.vertex = UnityObjectToClipPos(v.vertex);
+                o.screenPos = ComputeScreenPos(o.vertex);
                 return o;
             }
+
             fixed4 frag (v2f i) : SV_Target {
+                float sceneZ = tex2Dproj(_CameraDepthTexture, UNITY_PROJ_COORD(i.screenPos)).r;
+                float currentZ = i.screenPos.z / i.screenPos.w;
+
+                // Discard this fragment if it's behind what's already in the depth buffer
+                // (Unity uses a reversed-Z buffer on modern APIs, so LESS means FURTHER)
+                if (currentZ < sceneZ - 0.0001) {
+                    discard;
+                }
+
+                // Otherwise, it's visible, so draw the white mask
                 return fixed4(1.0, 1.0, 1.0, 1.0);
             }
             ENDCG


### PR DESCRIPTION
This commit addresses several issues with the pixelation post-processing effect, making it functional and stable, although a depth-testing issue remains.

Fixes:
- **Resolves initial rendering bug:** The effect was completely broken, rendering only a white triangle. This was fixed by refactoring the C# script to manually manage a Material and use `cmd.Blit` instead of `BlitFullscreenTriangle`, which was incompatible with the shader's vertex program.
- **Fixes `hard edges` feature:** The `hard edges` mode now works as intended. The shader logic was modified to sample the mask texture with pixelated coordinates, ensuring the effect's border is also pixelated.
- **Fixes Depth of Field (DoF) conflict:** The effect's execution order was changed from `AfterStack` to `BeforeStack`. This ensures it runs before DoF and other effects that could interfere with the depth buffer, resolving a major conflict.
- **Adds explicit projection matrix copy:** To improve the chances of the depth test working, a line was added to explicitly copy the main camera's projection matrix to the mask-rendering camera.

Remaining Issue:
- The effect is still visible through walls. Despite numerous attempts (direct depth comparison, reversed-Z, linearization, layer subtraction), the mask generation pass could not be made to correctly respect the main scene's depth buffer. This is likely due to a subtle issue in Unity's `camera.RenderWithShader` behavior or another project-specific configuration that cannot be diagnosed remotely.

This submission represents the best possible state of the effect given the circumstances, with major bugs and conflicts resolved.