### PR TITLE
Fix compilation errors in CensorEffect.cs for newer Unity versions.

### DIFF
--- a/Runtime/CensorEffect.cs
+++ b/Runtime/CensorEffect.cs
@@ -90,7 +90,14 @@ public sealed class CensorEffectRenderer : PostProcessEffectRenderer<CensorEffec
         }
         else
         {
-            cmd.Blit(context.source, context.destination, _censorMaterial, 0);
+            // The original Blit call (cmd.Blit(context.source, context.destination, _censorMaterial, 0))
+            // can fail on newer Unity versions due to ambiguity in overload resolution for RenderTargetIdentifier.
+            // A safer, more explicit approach is to blit to a temporary texture first, and then blit from
+            // that temporary texture to the destination with the material. This resolves the compiler errors.
+            var temp = RenderTexture.GetTemporary(context.width, context.height, 0, context.sourceFormat);
+            cmd.Blit(context.source, temp);
+            cmd.Blit(temp, context.destination, _censorMaterial, 0);
+            RenderTexture.ReleaseTemporary(temp);
         }
 
         RenderTexture.ReleaseTemporary(maskTexture);


### PR DESCRIPTION
The `CommandBuffer.Blit` call was failing due to compiler overload resolution issues with `RenderTargetIdentifier`. Replaced the direct blit with a two-stage blit using a temporary render texture to ensure compatibility.