### PR TITLE
This commit resolves several issues with the CensorEffect on newer ve…

### DIFF
--- a/Resources/WhiteMask.shader
+++ b/Resources/WhiteMask.shader
@@ -10,7 +10,8 @@ Shader "Hidden/CensorEffect/WhiteMask"
             #pragma fragment frag
             #include "UnityCG.cginc"
 
-            sampler2D _CensorDepthTexture;
+            // This is now populated by a dedicated command buffer at a reliable pipeline stage
+            sampler2D _CensorEffectDepthTexture;
 
             struct appdata {
                 float4 vertex : POSITION;
@@ -30,7 +31,7 @@ Shader "Hidden/CensorEffect/WhiteMask"
 
             fixed4 frag (v2f i) : SV_Target {
                 // Sample the raw depth from the main camera's depth texture.
-                float rawSceneZ = tex2Dproj(_CensorDepthTexture, UNITY_PROJ_COORD(i.screenPos)).r;
+                float rawSceneZ = tex2Dproj(_CensorEffectDepthTexture, UNITY_PROJ_COORD(i.screenPos)).r;
                 // Get the raw depth of the current fragment being rendered.
                 float rawCurrentZ = i.screenPos.z / i.screenPos.w;
 

--- a/Runtime/CensorEffect.cs
+++ b/Runtime/CensorEffect.cs
@@ -33,6 +33,10 @@ public sealed class CensorEffectRenderer : PostProcessEffectRenderer<CensorEffec
     private Shader _censorShader;
     private Shader _whiteMaskShader;
 
+    // Command buffer for grabbing depth texture at a reliable time
+    private CommandBuffer _depthGrabBuffer;
+    private Camera _lastCamera;
+
     public override void Init()
     {
         _censorShader = Shader.Find("Hidden/CensorEffect/Censor");
@@ -52,8 +56,36 @@ public sealed class CensorEffectRenderer : PostProcessEffectRenderer<CensorEffec
         _censorCamera.enabled = false;
     }
 
+    private void CleanupDepthGrab()
+    {
+        if (_lastCamera != null && _depthGrabBuffer != null)
+        {
+            _lastCamera.RemoveCommandBuffer(CameraEvent.AfterDepthTexture, _depthGrabBuffer);
+        }
+        _lastCamera = null;
+
+        _depthGrabBuffer?.Dispose();
+        _depthGrabBuffer = null;
+    }
+
     public override void Render(PostProcessRenderContext context)
     {
+        // The original method of grabbing the depth texture was not reliable, especially when
+        // other effects like SSR were active. They could change the "current" depth texture.
+        // To fix this, we use a dedicated CommandBuffer on the camera itself, scheduled at
+        // CameraEvent.AfterDepthTexture. This runs before any post-processing and ensures
+        // we always get the main scene's depth buffer.
+        if (_depthGrabBuffer == null || _lastCamera != context.camera)
+        {
+            CleanupDepthGrab(); // Clean up old buffer if camera changes
+
+            _lastCamera = context.camera;
+            _depthGrabBuffer = new CommandBuffer { name = "Censor Effect Depth Grab" };
+            // Note: This texture name must match the one in WhiteMask.shader
+            _depthGrabBuffer.SetGlobalTexture("_CensorEffectDepthTexture", BuiltinRenderTextureType.Depth);
+            _lastCamera.AddCommandBuffer(CameraEvent.AfterDepthTexture, _depthGrabBuffer);
+        }
+
         context.camera.depthTextureMode |= DepthTextureMode.Depth;
 
         if (_censorMaterial == null || _whiteMaskShader == null)
@@ -67,12 +99,10 @@ public sealed class CensorEffectRenderer : PostProcessEffectRenderer<CensorEffec
 
         var maskTexture = RenderTexture.GetTemporary(context.width, context.height, 16, RenderTextureFormat.R8);
 
-        // It seems that when using RenderWithShader on a secondary camera, the built-in _CameraDepthTexture
-        // is not reliably passed. We can fix this by manually binding the depth texture to a custom global name.
-        cmd.SetGlobalTexture("_CensorDepthTexture", BuiltinRenderTextureType.Depth);
+        // The SetGlobalTexture call was moved to our dedicated command buffer.
+        // We no longer do it here.
 
         _censorCamera.CopyFrom(context.camera);
-        // Explicitly copy projection matrix for robust depth testing
         _censorCamera.projectionMatrix = context.camera.projectionMatrix;
         _censorCamera.cullingMask = settings.censorLayer.value;
         _censorCamera.clearFlags = CameraClearFlags.SolidColor;
@@ -90,7 +120,11 @@ public sealed class CensorEffectRenderer : PostProcessEffectRenderer<CensorEffec
         }
         else
         {
-            cmd.Blit(context.source, context.destination, _censorMaterial, 0);
+            // This two-step blit is a workaround for compiler errors on newer Unity versions.
+            var temp = context.GetScreenSpaceTemporaryRT(0, context.sourceFormat);
+            cmd.Blit(context.source, temp);
+            cmd.Blit(temp, context.destination, _censorMaterial, 0);
+            RenderTexture.ReleaseTemporary(temp);
         }
 
         RenderTexture.ReleaseTemporary(maskTexture);
@@ -99,6 +133,8 @@ public sealed class CensorEffectRenderer : PostProcessEffectRenderer<CensorEffec
 
     public override void Release()
     {
+        // Clean up our command buffer and other resources
+        CleanupDepthGrab();
         base.Release();
         if (_censorCamera != null) UnityEngine.Object.DestroyImmediate(_censorCamera.gameObject);
         if (_censorMaterial != null) UnityEngine.Object.DestroyImmediate(_censorMaterial);


### PR DESCRIPTION
…rsions of Unity using the Built-in Render Pipeline.

1.  **Fix Compilation Error (CS1503):**
    - The initial `CommandBuffer.Blit` call failed to compile on newer Unity versions due to an overload resolution issue with `RenderTargetIdentifier`.
    - This was fixed by replacing the single `Blit` call with a two-stage blit using a temporary render texture (`context.GetScreenSpaceTemporaryRT`).

2.  **Fix Mask/SSR Regression:**
    - The initial fix introduced a runtime bug where the censor mask would not work correctly, especially when Screen Space Reflections (SSR) were enabled.
    - This was caused by unreliable depth buffer access. Other effects like SSR would alter the "current" depth buffer before the Censor Effect could use it.
    - The final, robust solution implements a dedicated `CommandBuffer` attached to the camera at `CameraEvent.AfterDepthTexture`. This captures the main scene depth texture into a global texture (`_CensorEffectDepthTexture`) *before* any post-processing effects run.
    - The effect's shaders were updated to use this reliable depth texture, ensuring correct mask rendering regardless of other active effects.
    - The command buffer is now correctly managed across camera changes and during the effect's release lifecycle.